### PR TITLE
CASC-237 Make OpenSAML bootstrap conditional.

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/Saml11TicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/Saml11TicketValidator.java
@@ -56,8 +56,11 @@ public final class Saml11TicketValidator extends AbstractUrlBasedTicketValidator
 
     static {
         try {
-            // we really only need to do this once, so this is why its here.
-            DefaultBootstrap.bootstrap();
+            // Check for prior OpenSAML initialization to prevent double init
+            // that would overwrite existing OpenSAML configuration
+            if (Configuration.getParserPool() == null) {
+                DefaultBootstrap.bootstrap();
+            }
         } catch (final ConfigurationException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Branching on `Configuration.getParserPool()` seems reasonable since OpenSAML simply won't work without that configured, so it's a reasonable test of prior initialization.