### PR TITLE
All URIBuilder parameter adding/setting operations should check for list emptiness...

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
@@ -373,7 +373,7 @@ public final class URIBuilder {
      * </p>
      */
     public URIBuilder setParameters(final BasicNameValuePair... nvps) {
-        if (this.queryParams == null) {
+        if (this.queryParams == null || this.queryParams.isEmpty()) {
             this.queryParams = new ArrayList<BasicNameValuePair>();
         } else {
             this.queryParams.clear();
@@ -396,7 +396,7 @@ public final class URIBuilder {
      * </p>
      */
     public URIBuilder addParameter(final String param, final String value) {
-        if (this.queryParams == null) {
+        if (this.queryParams == null || this.queryParams.isEmpty()) {
             this.queryParams = new ArrayList<BasicNameValuePair>();
         }
         this.queryParams.add(new BasicNameValuePair(param, value));
@@ -415,7 +415,7 @@ public final class URIBuilder {
      * </p>
      */
     public URIBuilder setParameter(final String param, final String value) {
-        if (this.queryParams == null) {
+        if (this.queryParams == null || this.queryParams.isEmpty()) {
             this.queryParams = new ArrayList<BasicNameValuePair>();
         }
         if (!this.queryParams.isEmpty()) {


### PR DESCRIPTION
as it may be from Collections.emptyList() and throws an UnsupportedOperationException when adding members.  This extends the logic introduced in 3080484a885987e4043ab10805cbd28ac0771d44

We've been hit by this bug in production when CAS redirection tries to parse a deep link.  Associated stack trace follows.  It looks like @mmoayyed shored up one of the methods but others are susceptible to the same issue.

```
java.lang.UnsupportedOperationException
        at java.util.AbstractList.add(AbstractList.java:148)
        at java.util.AbstractList.add(AbstractList.java:108)
        at org.jasig.cas.client.util.URIBuilder.addParameter(URIBuilder.java:402)
        at org.jasig.cas.client.util.CommonUtils.constructServiceUrl(CommonUtils.java:310)
        at org.jasig.cas.client.util.AbstractCasFilter.constructServiceUrl(AbstractCasFilter.java:104)
        at org.jasig.cas.client.authentication.AuthenticationFilter.doFilter(AuthenticationFilter.java:159)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:106)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:502)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:142)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:79)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:88)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:518)
        at org.apache.coyote.ajp.AbstractAjpProcessor.process(AbstractAjpProcessor.java:844)
        at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:668)
        at org.apache.tomcat.util.net.AprEndpoint$SocketProcessor.doRun(AprEndpoint.java:2463)
        at org.apache.tomcat.util.net.AprEndpoint$SocketProcessor.run(AprEndpoint.java:2452)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:745)
```