### PR TITLE
Issue #131 - ConfigurationStrategyName does not Properly Resolve Cust…

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationStrategyName.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationStrategyName.java
@@ -62,7 +62,7 @@ public enum ConfigurationStrategyName {
         try {
             final Class<?> clazz = Class.forName(value);
 
-            if (clazz.isAssignableFrom(ConfigurationStrategy.class)) {
+            if (ConfigurationStrategy.class.isAssignableFrom(clazz)) {
                 return (Class<? extends ConfigurationStrategy>) clazz;
             }
         }   catch (final ClassNotFoundException e) {

--- a/cas-client-core/src/test/java/org/jasig/cas/client/configuration/ConfigurationStrategyNameTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/configuration/ConfigurationStrategyNameTests.java
@@ -20,6 +20,9 @@ package org.jasig.cas.client.configuration;
 
 import org.junit.Test;
 
+import javax.servlet.Filter;
+import javax.servlet.FilterConfig;
+
 import static org.junit.Assert.*;
 
 public final class ConfigurationStrategyNameTests {
@@ -32,5 +35,23 @@ public final class ConfigurationStrategyNameTests {
         assertEquals(SystemPropertiesConfigurationStrategyImpl.class, ConfigurationStrategyName.resolveToConfigurationStrategy(ConfigurationStrategyName.SYSTEM_PROPERTIES.name()));
         assertEquals(LegacyConfigurationStrategyImpl.class, ConfigurationStrategyName.resolveToConfigurationStrategy(ConfigurationStrategyName.DEFAULT.name()));
         assertEquals(LegacyConfigurationStrategyImpl.class, ConfigurationStrategyName.resolveToConfigurationStrategy("bleh!"));
+    }
+
+
+    @Test
+    public void resolveToClass() {
+        assertEquals(TestClass.class, ConfigurationStrategyName.resolveToConfigurationStrategy(TestClass.class.getName()));
+    }
+
+    private class TestClass extends BaseConfigurationStrategy {
+
+        @Override
+        protected String get(ConfigurationKey configurationKey) {
+            return null;
+        }
+
+        public void init(FilterConfig filterConfig, Class<? extends Filter> filterClazz) {
+
+        }
     }
 }


### PR DESCRIPTION
…om classes

Problem: The assignable check was reversed, always resulting in a false return value.
Solution: Add test to confirm failure and then swap check.  Unit tests pass.