### PR TITLE
CASC-127 Remove Commons Codec Dependency

### DIFF
--- a/cas-client-core/pom.xml
+++ b/cas-client-core/pom.xml
@@ -37,14 +37,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.4</version>
-            <type>jar</type>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <version>${spring.version}</version>

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
@@ -19,6 +19,7 @@
 package org.jasig.cas.client.session;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.zip.Inflater;
 
@@ -26,8 +27,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.xml.bind.DatatypeConverter;
 
-import org.apache.commons.codec.binary.Base64;
 import org.jasig.cas.client.Protocol;
 import org.jasig.cas.client.configuration.ConfigurationKeys;
 import org.jasig.cas.client.util.CommonUtils;
@@ -146,7 +147,7 @@ public final class SingleSignOutHandler {
             if (this.artifactParameterOverPost) {
                 this.safeParameters = Arrays.asList(this.logoutParameterName, this.artifactParameterName);
             } else {
-                this.safeParameters = Arrays.asList(this.logoutParameterName);
+                this.safeParameters = Collections.singletonList(this.logoutParameterName);
             }
         }
     }
@@ -256,7 +257,7 @@ public final class SingleSignOutHandler {
      * @return the uncompressed logout message.
      */
     private String uncompressLogoutMessage(final String originalMessage) {
-        final byte[] binaryMessage = Base64.decodeBase64(originalMessage);
+        final byte[] binaryMessage = DatatypeConverter.parseBase64Binary(originalMessage);
 
         Inflater decompresser = null;
         try {

--- a/cas-client-core/src/test/java/org/jasig/cas/client/session/LogoutMessageGenerator.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/session/LogoutMessageGenerator.java
@@ -18,11 +18,10 @@
  */
 package org.jasig.cas.client.session;
 
+import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.zip.Deflater;
-
-import org.apache.commons.codec.binary.Base64;
 
 /**
  * Logout message generator to perform tests on Single Sign Out feature.
@@ -51,6 +50,6 @@ public final class LogoutMessageGenerator {
         final int resultSize = deflater.deflate(buffer);
         final byte[] output = new byte[resultSize];
         System.arraycopy(buffer, 0, output, 0, resultSize);
-        return Base64.encodeBase64String(output);
+        return DatatypeConverter.printBase64Binary(output);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Problem: We rely on Commons Codec for some simple Base64 decoding/encoding, most of which is available in Java 1.6+
Solution: Set minimum version to Java 1.6 and rely on provided methods.

QA Notes: Unit tests pass

Handles #127 and #121 